### PR TITLE
Fixed the __dict__ and __weakref__ bug

### DIFF
--- a/src/binary_structs/binary_struct.py
+++ b/src/binary_structs/binary_struct.py
@@ -430,7 +430,12 @@ def _process_class(cls):
     if not issubclass(cls, BinaryField):
         cls_bases = tuple() if cls.__bases__ == (object,) else cls.__bases__
         cls_bases += (BinaryField,)
-        cls = type(cls.__name__, cls_bases, dict(cls.__dict__))
+
+        new_dict = dict(cls.__dict__)
+        new_dict.pop('__dict__', None)
+        new_dict.pop('__weakref__', None)
+
+        cls = type(cls.__name__, cls_bases, new_dict)
 
     # These will be used for creating the new class
     # They are the same as annotations, but they contain the default value too

--- a/unittests/binary_struct/test_binary_struct_endianness.py
+++ b/unittests/binary_struct/test_binary_struct_endianness.py
@@ -1,6 +1,9 @@
 import pytest
 
 from binary_structs import *
+from conftest import available_decorators
+
+decorators_without_format = [decorator[0] for decorator in available_decorators]
 
 
 # Initialization testing
@@ -222,3 +225,16 @@ def test_invalid_init_incompatible_type():
     a = A(5)
     with pytest.raises(TypeError):
         B(a)
+
+
+@pytest.mark.parametrize('decorator', decorators_without_format)
+def test_valid_init_class_dict_and_weakref_not_broken_after_conversion(decorator):
+    class A:
+        pass
+
+    B = decorator(binary_struct(A))
+
+    assert A.__dict__ is not B.__dict__
+    assert A().__dict__ is not B().__dict__
+
+    assert A.__weakref__ is not B.__weakref__


### PR DESCRIPTION
Since dict(cls.__dict__) was used, members such as __dict__ and __weakref__ were not deepcopied.
This resulted in the __dict__ and __weakref__ attributes being invalid